### PR TITLE
Removing lambda from title_patterns as no longer necessary

### DIFF
--- a/lib/puppet/type/yaml_setting.rb
+++ b/lib/puppet/type/yaml_setting.rb
@@ -164,20 +164,19 @@ Puppet::Type.newtype(:yaml_setting) do
   # Our title_patterns method for mapping titles to namevars for supporting
   # composite namevars.
   def self.title_patterns
-    identity = lambda {|x| x}
     [
       [
         /^([^:]+)$/,
         [
-          [ :name, identity ]
+          [ :name ]
         ]
       ],
       [
         /^((.*):(.*))$/,
         [
-          [ :name, identity ],
-          [ :key, identity ],
-          [ :value, identity ]
+          [ :name ],
+          [ :key ],
+          [ :value ]
         ]
       ]
     ]


### PR DESCRIPTION
Supposedly this is no longer necessary:

https://github.com/puppetlabs/puppet/commit/89e0f142044ebf132f39c141a7b7d600b04a922d

And we've noticed it causing errors with the new type generation functionality in PE:

“Error: /etc/puppetlabs/code/environments/master/modules/yamlfile/lib/puppet/type/yaml_setting.rb: title patterns that use procs are not supported.”