### PR TITLE
Updated 'Fixnum' to 'Integer' as Fixnum was removed in Ruby 2.4 and later version

### DIFF
--- a/lib/puppet/provider/yaml_setting/mapped.rb
+++ b/lib/puppet/provider/yaml_setting/mapped.rb
@@ -103,7 +103,7 @@ Puppet::Type.type(:yaml_setting).provide(:mapped) do
       resource[:target] = filename
       resource[:name]   = "#{resource[:target].to_s}:#{resource[:key].to_s}"
       resource[:type]   = case resource[:value]
-      when Fixnum
+      when Integer
         'integer'
       when Symbol
         'symbol'


### PR DESCRIPTION
updated Fixnum to 'Integer' as Fixnum was removed in Ruby 2.4 and later versions